### PR TITLE
added support for alpha. Added option to provide build directly. Chan…

### DIFF
--- a/scripts/create_remote_scripts.py
+++ b/scripts/create_remote_scripts.py
@@ -86,7 +86,7 @@ def create_remote_chaincode_script(CONF, AWS, chaincode_remote_script):
             for peer in org['peers']:
                 if 'Tools' in peer:
                     chaincode_remote_script.write("cmd=\"docker exec -it tools.{0} bash -c\"\n".format(org['Domain']))
-                    template = "ssh -oStrictHostKeyChecking=no -i {0} -t {1}@tools.{2} $cmd '\"/etc/hyperledger/chaincode_tools/update_chaincodes.py {3}\"'\n"
+                    template = "ssh -oStrictHostKeyChecking=no -i {0} -t {1}@tools.{2} $cmd '\"/etc/hyperledger/chaincode_tools/update_chaincodes.py --repository {3}\"'\n"
                     chaincode_remote_script.write(template.format(
                         AWS['private_key_path'],
                         AWS['ssh_username'],

--- a/shared/chaincode_tools/update_chaincodes.py
+++ b/shared/chaincode_tools/update_chaincodes.py
@@ -25,7 +25,7 @@ The script looks for a file $GOPATH/src/chaincodes.json which must contain the p
 """, formatter_class=RawTextHelpFormatter)
 PARSER.add_argument('--dryrun', help='Shows which commands would be run, without running them', action='store_true')
 PARSER.add_argument('--repository', '-r', type=str,help='the repository from which the chaincode should be fetched. If not given, assumes chaincodes are in $GOPATH/src/build/')
-PARSER.add_argument('--forceRebuild', '-f', help='forces the script to run npm install on each chaincode. By default it will only run npm install when the node_modules directory for that chaincode is missing', action='store_true')
+PARSER.add_argument('--forceNpmInstall', '-f', help='forces the script to run npm install on each chaincode. By default it will only run npm install when the node_modules directory for that chaincode is missing', action='store_true')
 
 args = PARSER.parse_args()
 DRYRUN = args.dryrun
@@ -88,7 +88,7 @@ def compile_chaincode(data):
         call("/etc/hyperledger/chaincode_tools/compile_chaincode.sh", data['chaincode_path'])
         return "==> Compiled " + data['info'] + "!"
     elif data['chaincode_language'] == "node":
-        if not os.path.isdir(data['chaincode_path'] + '/node_modules') or args.forceRebuild:
+        if not os.path.isdir(data['chaincode_path'] + '/node_modules') or args.forceNpmInstall:
             call("npm", "install", "--prefix", data['chaincode_path'])
         return "==> Installed NPM for " + data['info'] + "!"
 

--- a/shared/chaincode_tools/update_chaincodes.py
+++ b/shared/chaincode_tools/update_chaincodes.py
@@ -21,11 +21,11 @@ The script looks for a file $GOPATH/src/chaincodes.json which must contain the p
 * For nodejs chaincode only:
     > Compiled Nodejs chaincodes will be in $GOPATH/src/build.
     > If you provide a repository, this will pull from it and save it in $GOPATH/src/, and then run `npm run build`, which must create the $GOPATH/src/build folder, containing chaincodes.
-    > If $GOPATH/src/build/<chaincode_name>/node_modules does not exists, the script will run `npm install` in that chaincode directory, otherwise it will skip `npm install`.
     > If no repository is given, the script will only look in $GOPATH/src/build, making the contents of $GOPATH/src/chaincodes optional.
 """, formatter_class=RawTextHelpFormatter)
 PARSER.add_argument('--dryrun', help='Shows which commands would be run, without running them', action='store_true')
 PARSER.add_argument('--repository', '-r', type=str,help='the repository from which the chaincode should be fetched. If not given, assumes chaincodes are in $GOPATH/src/build/')
+PARSER.add_argument('--forceRebuild', '-f', help='forces the script to run npm install on each chaincode. By default it will only run npm install when the node_modules directory for that chaincode is missing', action='store_true')
 
 args = PARSER.parse_args()
 DRYRUN = args.dryrun
@@ -88,7 +88,7 @@ def compile_chaincode(data):
         call("/etc/hyperledger/chaincode_tools/compile_chaincode.sh", data['chaincode_path'])
         return "==> Compiled " + data['info'] + "!"
     elif data['chaincode_language'] == "node":
-        if not os.path.isdir(data['chaincode_path'] + '/node_modules'):
+        if not os.path.isdir(data['chaincode_path'] + '/node_modules') or args.forceRebuild:
             call("npm", "install", "--prefix", data['chaincode_path'])
         return "==> Installed NPM for " + data['info'] + "!"
 


### PR DESCRIPTION
added support for alpha. Added option to provide build directly. Changed arg parser. You'll need to adapt scripts to pass --repository <repositoryName> as argument, otherwise it assumes you gave the chaincodes already built.